### PR TITLE
Build V8 to dylibs and link rusty_v8 against those

### DIFF
--- a/.gn
+++ b/.gn
@@ -20,7 +20,6 @@ default_args = {
   clang_use_chrome_plugins = false
   v8_use_external_startup_data = false
   v8_enable_symbol_visibility = true
-  symbol_level = 2
   use_custom_libcxx = true
   # trying to get cppgc build
   v8_enable_oilpan=true
@@ -35,7 +34,6 @@ default_args = {
   # Minimize size of debuginfo in distributed static library.
   line_tables_only = true
   no_inline_line_tables = true
-  symbol_level = 1
   use_debug_fission = false
 
   v8_enable_sandbox = false

--- a/.gn
+++ b/.gn
@@ -18,7 +18,7 @@ secondary_source = "//v8/"
 
 default_args = {
   clang_use_chrome_plugins = false
-  is_component_build = false
+  is_component_build = true
   linux_use_bundled_binutils = false
   use_dummy_lastchange = true
   use_sysroot = false

--- a/.gn
+++ b/.gn
@@ -81,4 +81,6 @@ default_args = {
 
   # Enable Deno-specific extra bindings
   deno_enable_extras = true
+
+  v8_monolithic = true
 }

--- a/.gn
+++ b/.gn
@@ -20,7 +20,6 @@ default_args = {
   clang_use_chrome_plugins = false
   v8_use_external_startup_data = false
   v8_enable_symbol_visibility = true
-  default_symbol_visibility = "hidden"
   symbol_level = 2
   use_custom_libcxx = true
   # trying to get cppgc build

--- a/.gn
+++ b/.gn
@@ -22,6 +22,7 @@ default_args = {
   v8_use_external_startup_data = false
   v8_enable_symbol_visibility = true
   symbol_level = 2
+  use_custom_libcxx = true
   # trying to get cppgc build
   v8_enable_oilpan=true
   treat_warnings_as_errors = false

--- a/.gn
+++ b/.gn
@@ -22,7 +22,7 @@ default_args = {
   v8_use_external_startup_data = false
   v8_enable_symbol_visibility = true
   symbol_level = 2
-  use_custom_libcxx = false
+  use_custom_libcxx = true
   # trying to get cppgc build
   v8_enable_oilpan=true
   is_debug = false

--- a/.gn
+++ b/.gn
@@ -19,6 +19,15 @@ secondary_source = "//v8/"
 default_args = {
   clang_use_chrome_plugins = false
   is_component_build = true
+  v8_use_external_startup_data = false
+  v8_enable_symbol_visibility = true
+  symbol_level = 2
+  use_custom_libcxx = false
+  # trying to get cppgc build
+  v8_enable_oilpan=true
+  is_debug = false
+  
+
   linux_use_bundled_binutils = false
   use_dummy_lastchange = true
   use_sysroot = false
@@ -81,6 +90,4 @@ default_args = {
 
   # Enable Deno-specific extra bindings
   deno_enable_extras = true
-
-  v8_monolithic = true
 }

--- a/.gn
+++ b/.gn
@@ -24,6 +24,7 @@ default_args = {
   symbol_level = 2
   # trying to get cppgc build
   v8_enable_oilpan=true
+  treat_warnings_as_errors = false
   
 
   linux_use_bundled_binutils = false

--- a/.gn
+++ b/.gn
@@ -29,6 +29,7 @@ default_args = {
   # Minimize size of debuginfo in distributed static library.
   line_tables_only = true
   no_inline_line_tables = true
+  symbol_level = 1
   use_debug_fission = false
 
   v8_enable_sandbox = false

--- a/.gn
+++ b/.gn
@@ -18,9 +18,9 @@ secondary_source = "//v8/"
 
 default_args = {
   clang_use_chrome_plugins = false
-  is_component_build = true
   v8_use_external_startup_data = false
   v8_enable_symbol_visibility = true
+  default_symbol_visibility = "hidden"
   symbol_level = 2
   use_custom_libcxx = true
   # trying to get cppgc build

--- a/.gn
+++ b/.gn
@@ -18,13 +18,8 @@ secondary_source = "//v8/"
 
 default_args = {
   clang_use_chrome_plugins = false
-  v8_use_external_startup_data = false
-  v8_enable_symbol_visibility = true
-  use_custom_libcxx = true
-  # trying to get cppgc build
-  v8_enable_oilpan=true
+  is_component_build = false
   treat_warnings_as_errors = false
-  
 
   linux_use_bundled_binutils = false
   use_dummy_lastchange = true

--- a/.gn
+++ b/.gn
@@ -22,7 +22,6 @@ default_args = {
   v8_use_external_startup_data = false
   v8_enable_symbol_visibility = true
   symbol_level = 2
-  use_custom_libcxx = true
   # trying to get cppgc build
   v8_enable_oilpan=true
   is_debug = false

--- a/.gn
+++ b/.gn
@@ -24,7 +24,6 @@ default_args = {
   symbol_level = 2
   # trying to get cppgc build
   v8_enable_oilpan=true
-  is_debug = false
   
 
   linux_use_bundled_binutils = false

--- a/build.rs
+++ b/build.rs
@@ -622,9 +622,17 @@ fn print_link_flags() {
   println!("cargo:rustc-link-search=native=./target/release/gn_out");
 
   // Link dynamic V8 libraries
-  println!("cargo:rustc-link-lib=dylib=v8");
+  
   println!("cargo:rustc-link-lib=dylib=v8_libplatform");
   println!("cargo:rustc-link-lib=dylib=v8_libbase");
+  println!("cargo:rustc-link-lib=dylib=v8");
+  println!("cargo:rustc-link-lib=dylib=c++_chrome");
+  println!("cargo:rustc-link-lib=dylib=third_party_icu_icui18n");
+  println!("cargo:rustc-link-lib=dylib=icuuc");
+  println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
+  println!("cargo:rustc-link-lib=dylib=cppgc");
+  println!("cargo:rustc-link-lib=dylib=cppgc_base");
+  println!("cargo:rustc-link-lib=dylib=cppgc_shared");
   // Add other necessary libraries...
 
   // Platform-specific linker arguments

--- a/build.rs
+++ b/build.rs
@@ -152,8 +152,6 @@ fn build_v8(is_asan: bool) {
   } else {
     vec!["is_debug=false".to_string()]
   };
-  let symbol_level = if is_debug() { "2" } else { "1" };
-  gn_args.push(format!("symbol_level={}", symbol_level));
   if is_asan {
     gn_args.push("is_asan=true".to_string());
   }

--- a/build.rs
+++ b/build.rs
@@ -159,35 +159,6 @@ fn build_v8(is_asan: bool) {
     gn_args.push("use_custom_libcxx=false".to_string());
   }
 
-  // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
-  if cfg!(target_os = "macos") {
-    let host_arch = std::env::var("HOST_ARCH").unwrap_or_else(|_| {
-      // Detect the host architecture
-      match std::env::consts::ARCH {
-          "x86_64" => "x64".to_string(),
-          "aarch64" => "arm64".to_string(),
-          other => other.to_string(),
-      }
-    });
-  
-    let target_cpu = match target_arch.as_str() {
-        "x86_64" => "x64",
-        "aarch64" => "arm64",
-        _ => panic!("Unsupported architecture"),
-    };
-  
-    gn_args.push(format!("target_cpu=\"{}\"", target_cpu));
-    gn_args.push(format!("host_cpu=\"{}\"", host_arch));
-
-    if target_arch == "x86_64" {
-      gn_args.push(r#"extra_cflags = [ "-arch", "x86_64" ]"#.to_string());
-      gn_args.push(r#"extra_ldflags = [ "-arch", "x86_64" ]"#.to_string());
-    } else if target_arch == "aarch64" {
-      gn_args.push(r#"extra_cflags = [ "-arch", "arm64" ]"#.to_string());
-      gn_args.push(r#"extra_ldflags = [ "-arch", "arm64" ]"#.to_string());
-    }
-  }
-
   gn_args.push(r#"default_symbol_visibility = "hidden""#.to_string());
   let repo_root = env::current_dir().unwrap();
   let abseil_options_path = repo_root
@@ -207,6 +178,33 @@ fn build_v8(is_asan: bool) {
   if cfg!(target_os = "macos") {
     gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
     gn_args.push(r#"extra_ldflags = [ "-Wl,-x" ]"#.to_string());
+
+    // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
+    let host_arch = std::env::var("HOST_ARCH").unwrap_or_else(|_| {
+      // Detect the host architecture
+      match std::env::consts::ARCH {
+          "x86_64" => "x64".to_string(),
+          "aarch64" => "arm64".to_string(),
+          other => other.to_string(),
+      }
+    });
+  
+    let target_cpu = match target_arch.as_str() {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        _ => panic!("Unsupported architecture"),
+    };
+  
+    gn_args.push(format!("target_cpu=\"{}\"", target_cpu));
+    gn_args.push(format!("host_cpu=\"{}\"", host_arch));
+
+    if target_arch == "x86_64" {
+      gn_args.push(r#"extra_cflags += [ "-arch", "x86_64" ]"#.to_string());
+      gn_args.push(r#"extra_ldflags += [ "-arch", "x86_64" ]"#.to_string());
+    } else if target_arch == "aarch64" {
+      gn_args.push(r#"extra_cflags += [ "-arch", "arm64" ]"#.to_string());
+      gn_args.push(r#"extra_ldflags += [ "-arch", "arm64" ]"#.to_string());
+    }
   }
 
   if env::var_os("DISABLE_CLANG").is_some() {

--- a/build.rs
+++ b/build.rs
@@ -993,6 +993,7 @@ pub fn build(target: &str, maybe_env: Option<NinjaEnv>) {
     fs::create_dir_all(&gn_out_dir).expect("Failed to create gn_out_dir");
   }
 
+  println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
   rerun_if_changed(&gn_out_dir, maybe_env.clone(), target);
 
   // This helps Rust source files locate the snapshot, source map etc.

--- a/build.rs
+++ b/build.rs
@@ -91,8 +91,10 @@ fn main() {
     false
   };
 
-  // Build from source
-  if env::var_os("V8_FROM_SOURCE").is_some() {
+
+  // Build from source -- FORCED for dynamic library build
+  // if env_bool("V8_FROM_SOURCE") {
+  if true {
     if is_asan && std::env::var_os("OPT_LEVEL").unwrap_or_default() == "0" {
       panic!("v8 crate cannot be compiled with OPT_LEVEL=0 and ASAN.\nTry `[profile.dev.package.v8] opt-level = 1`.\nAborting before miscompilations cause issues.");
     }

--- a/build.rs
+++ b/build.rs
@@ -152,6 +152,8 @@ fn build_v8(is_asan: bool) {
   } else {
     vec!["is_debug=false".to_string()]
   };
+  let symbol_level = if is_debug() { "2" } else { "1" };
+  gn_args.push(format!("symbol_level={}", symbol_level));
   if is_asan {
     gn_args.push("is_asan=true".to_string());
   }

--- a/build.rs
+++ b/build.rs
@@ -1016,7 +1016,7 @@ pub fn build(target: &str, maybe_env: Option<NinjaEnv>) {
   }
 
   println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
-  println!("cargo:rerun-if-env-changed=PROFILE");
+  //println!("cargo:rerun-if-env-changed=PROFILE");
   rerun_if_changed(&gn_out_dir, maybe_env.clone(), target);
 
   // This helps Rust source files locate the snapshot, source map etc.

--- a/build.rs
+++ b/build.rs
@@ -630,9 +630,9 @@ fn print_link_flags() {
   println!("cargo:rustc-link-lib=dylib=third_party_icu_icui18n");
   println!("cargo:rustc-link-lib=dylib=icuuc");
   println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
-  println!("cargo:rustc-link-lib=dylib=cppgc");
-  println!("cargo:rustc-link-lib=dylib=cppgc_base");
-  println!("cargo:rustc-link-lib=dylib=cppgc_shared");
+  
+  println!("cargo:rustc-cdylib-link-arg=-D_LIBCPP_ABI_VERSION=1");
+
   // Add other necessary libraries...
 
   // Platform-specific linker arguments

--- a/build.rs
+++ b/build.rs
@@ -777,15 +777,16 @@ fn find_compatible_system_clang(target_os: &str) -> Option<PathBuf> {
       None
     }
   } else if target_os == "windows" {
-    let llvm_path = Path::new("C:\\")
-        .join("Program Files")
+    let _llvm_path = Path::new("C:\\")
+        .join("Program Files (x86)")
         .join("Microsoft Visual Studio")
         .join("2022")
-        .join("Community")
+        .join("BuildTools")
         .join("VC")
         .join("Tools")
         .join("Llvm");
 
+    let llvm_path = Path::new("C:\\").join("LLVM");
     let clang_path = llvm_path.clone()
       .join("bin")
       .join("clang-cl.exe");
@@ -794,7 +795,7 @@ fn find_compatible_system_clang(target_os: &str) -> Option<PathBuf> {
 
     if is_compatible_clang_version(&clang_path_str) {
       deactivate_lld();
-      return Some(clang_path);
+      return Some(llvm_path);
     } else {
       None
     }

--- a/build.rs
+++ b/build.rs
@@ -625,8 +625,10 @@ fn copy_archive(url: &str, filename: &Path) {
 }
 
 fn print_link_flags() {
+  let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+  
   println!("cargo:rustc-link-lib=static=rusty_v8");
-  println!("cargo:rustc-link-search=native=./target/release/gn_out");
+  println!("cargo:rustc-link-search=native=./target/release/gn_out/{}", target_arch);
 
   println!("cargo:rustc-link-lib=dylib=v8_libplatform");
   println!("cargo:rustc-link-lib=dylib=v8_libbase");

--- a/build.rs
+++ b/build.rs
@@ -1018,6 +1018,7 @@ pub fn build(target: &str, maybe_env: Option<NinjaEnv>) {
   }
 
   println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
+  println!("cargo:rerun-if-env-changed=PROFILE");
   rerun_if_changed(&gn_out_dir, maybe_env.clone(), target);
 
   // This helps Rust source files locate the snapshot, source map etc.

--- a/build.rs
+++ b/build.rs
@@ -170,15 +170,7 @@ fn build_v8(is_asan: bool) {
 
   modify_abseil_options(&abseil_options_path).expect("Failed to modify options.h");
 
-  if cfg!(target_os = "linux") {
-    gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
-    gn_args.push(r#"extra_ldflags = [ "-Wl,-Bsymbolic" ]"#.to_string());
-  }
-
   if cfg!(target_os = "macos") {
-    gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
-    gn_args.push(r#"extra_ldflags = [ "-Wl,-x" ]"#.to_string());
-
     // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
     let host_arch = std::env::var("HOST_ARCH").unwrap_or_else(|_| {
       // Detect the host architecture

--- a/build.rs
+++ b/build.rs
@@ -164,27 +164,26 @@ fn build_v8(is_asan: bool) {
     gn_args.push("host_cpu=\"arm64\"".to_string())
   }
 
-  if cfg!(target_os = "macos") {
-    gn_args.push(r#"is_component_build = true"#.to_string());
-  } else {
-    gn_args.push(r#"default_symbol_visibility = "hidden""#.to_string());
-    let repo_root = env::current_dir().unwrap();
-    let abseil_options_path = repo_root
-      .join("third_party")
-      .join("abseil-cpp")
-      .join("absl")
-      .join("base")
-      .join("options.h");
+  gn_args.push(r#"default_symbol_visibility = "hidden""#.to_string());
+  let repo_root = env::current_dir().unwrap();
+  let abseil_options_path = repo_root
+    .join("third_party")
+    .join("abseil-cpp")
+    .join("absl")
+    .join("base")
+    .join("options.h");
 
-    modify_abseil_options(&abseil_options_path).expect("Failed to modify options.h");
+  modify_abseil_options(&abseil_options_path).expect("Failed to modify options.h");
 
-    if cfg!(target_os = "linux") {
-      gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
-      gn_args.push(r#"extra_ldflags = [ "-Wl,-Bsymbolic" ]"#.to_string());
-    }
+  if cfg!(target_os = "linux") {
+    gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
+    gn_args.push(r#"extra_ldflags = [ "-Wl,-Bsymbolic" ]"#.to_string());
   }
 
-  
+  if cfg!(target_os = "macos") {
+    gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
+    gn_args.push(r#"extra_ldflags = [ "-Wl,-x" ]"#.to_string());
+  }
 
   if env::var_os("DISABLE_CLANG").is_some() {
     gn_args.push("is_clang=false".into());
@@ -641,10 +640,9 @@ fn copy_archive(url: &str, filename: &Path) {
 }
 
 fn print_link_flags() {
-  
-  
   println!("cargo:rustc-link-lib=static=rusty_v8");
 
+  /*
   // Platform-specific linker arguments
   if cfg!(target_os = "macos") {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
@@ -662,6 +660,7 @@ fn print_link_flags() {
       // Windows uses a different mechanism; rpath is not used
       // You might need to copy the DLLs next to the executable
   }
+   */
   let should_dyn_link_libcxx = env::var("CARGO_FEATURE_USE_CUSTOM_LIBCXX")
     .is_err()
     || env::var("GN_ARGS").map_or(false, |gn_args| {

--- a/build.rs
+++ b/build.rs
@@ -550,7 +550,7 @@ where
   let mut inflate_state = InflateState::default();
   let mut input_buffer = [0; 16 * 1024];
   let mut output_buffer = [0; 16 * 1024];
-  let mut input_offset = 0;
+  let mut input_offset = 0; 
 
   // Skip the gzip header
   gzip_header::read_gz_header(input).unwrap();
@@ -622,23 +622,27 @@ fn print_link_flags() {
   println!("cargo:rustc-link-lib=static=rusty_v8");
   println!("cargo:rustc-link-search=native=./target/release/gn_out");
 
-  // Link dynamic V8 libraries
-  
-  println!("cargo:rustc-link-lib=dylib=v8_libplatform");
-  println!("cargo:rustc-link-lib=dylib=v8_libbase");
-  println!("cargo:rustc-link-lib=dylib=v8");
-  println!("cargo:rustc-link-lib=dylib=c++_chrome");
-  println!("cargo:rustc-link-lib=dylib=third_party_icu_icui18n");
-  println!("cargo:rustc-link-lib=dylib=icuuc");
-  println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
-
-  // Add other necessary libraries...
-
   // Platform-specific linker arguments
   if cfg!(target_os = "macos") {
+      // Link dynamic V8 libraries  
+      println!("cargo:rustc-link-lib=dylib=v8_libplatform");
+      println!("cargo:rustc-link-lib=dylib=v8_libbase");
+      println!("cargo:rustc-link-lib=dylib=v8");
+      println!("cargo:rustc-link-lib=dylib=c++_chrome");
+      println!("cargo:rustc-link-lib=dylib=third_party_icu_icui18n");
+      println!("cargo:rustc-link-lib=dylib=icuuc");
+      println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
       // macOS specific rpath
       println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../lib");
   } else if cfg!(target_os = "linux") {
+    // Link dynamic V8 libraries  
+      println!("cargo:rustc-link-lib=so=libv8_libplatform");
+      println!("cargo:rustc-link-lib=so=libv8_libbase");
+      println!("cargo:rustc-link-lib=so=libv8");
+      println!("cargo:rustc-link-lib=so=libc++");
+      println!("cargo:rustc-link-lib=so=libthird_party_icu_icui18n");
+      println!("cargo:rustc-link-lib=so=libicuuc");
+      println!("cargo:rustc-link-lib=so=libthird_party_abseil-cpp_absl");
       // Linux specific rpath
       println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
   } else if cfg!(target_os = "windows") {
@@ -694,6 +698,7 @@ fn print_link_flags() {
   }
 }
 
+
 // Chromium depot_tools contains helpers
 // which delegate to the "relevant" `buildtools`
 // directory when invoked, so they don't count.
@@ -724,7 +729,7 @@ fn is_compatible_clang_version(clang_path: &str) -> bool {
     const _MIN_LLVM_CLANG_VER: f32 = 8.0;
     return true;
   }
-  false
+  true
 }
 
 fn deactivate_lld() {
@@ -761,13 +766,13 @@ fn find_compatible_system_clang(target_os: &str) -> Option<PathBuf> {
     }
   } else if target_os == "windows" {
     let llvm_path = Path::new("C:\\")
-      .join("\"Program Files (x86)\"")
-      .join("Microsoft Visual Studio")
-      .join("2022")
-      .join("BuildTools")
-      .join("VC")
-      .join("Tools")
-      .join("Llvm");
+        .join("Program Files")
+        .join("Microsoft Visual Studio")
+        .join("2022")
+        .join("Community")
+        .join("VC")
+        .join("Tools")
+        .join("Llvm");
 
     let clang_path = llvm_path.clone()
       .join("bin")
@@ -777,7 +782,7 @@ fn find_compatible_system_clang(target_os: &str) -> Option<PathBuf> {
 
     if is_compatible_clang_version(&clang_path_str) {
       deactivate_lld();
-      return Some(llvm_path);
+      return Some(clang_path);
     } else {
       None
     }
@@ -895,7 +900,9 @@ pub fn is_debug() -> bool {
 }
 
 fn gn() -> String {
-  env::var("GN").unwrap_or_else(|_| "gn".to_owned())
+  let gn = env::var("GN").unwrap_or_else(|_| "gn".to_owned());
+  println!("Using gn: {}", gn.clone());
+  gn
 }
 
 /*
@@ -903,13 +910,16 @@ fn gn() -> String {
  * variable or defaulting to `python3`.
  */
 fn python() -> String {
-  env::var("PYTHON").unwrap_or_else(|_| "python3".to_owned())
+  let python = env::var("PYTHON").unwrap_or_else(|_| "python3".to_owned());
+  println!("Using python: {}", python);
+  env::var("PYTHON").unwrap_or_else(|_| "python".to_owned())
 }
 
 type NinjaEnv = Vec<(String, String)>;
 
 fn ninja(gn_out_dir: &Path, maybe_env: Option<NinjaEnv>) -> Command {
-  let cmd_string = env::var("NINJA").unwrap_or_else(|_| "ninja".to_owned());
+  let cmd_string = env::var("NINJA").unwrap_or_else(|_| "C:\\Strawberry\\c\\bin\\ninja.exe".to_owned());
+  println!("Using ninja: {}", cmd_string);
   let mut cmd = Command::new(cmd_string);
   cmd.arg("-C");
   cmd.arg(gn_out_dir);

--- a/build.rs
+++ b/build.rs
@@ -191,11 +191,11 @@ fn build_v8(is_asan: bool) {
     gn_args.push(format!("host_cpu=\"{}\"", host_arch));
 
     if target_arch == "x86_64" {
-      gn_args.push(r#"extra_cflags += [ "-arch", "x86_64" ]"#.to_string());
-      gn_args.push(r#"extra_ldflags += [ "-arch", "x86_64" ]"#.to_string());
+      gn_args.push(r#"extra_cflags = [ "-arch", "x86_64" ]"#.to_string());
+      gn_args.push(r#"extra_ldflags = [ "-arch", "x86_64" ]"#.to_string());
     } else if target_arch == "aarch64" {
-      gn_args.push(r#"extra_cflags += [ "-arch", "arm64" ]"#.to_string());
-      gn_args.push(r#"extra_ldflags += [ "-arch", "arm64" ]"#.to_string());
+      gn_args.push(r#"extra_cflags = [ "-arch", "arm64" ]"#.to_string());
+      gn_args.push(r#"extra_ldflags = [ "-arch", "arm64" ]"#.to_string());
     }
   }
 

--- a/build.rs
+++ b/build.rs
@@ -168,7 +168,7 @@ fn build_v8(is_asan: bool) {
     gn_args.push("is_clang=false".into());
     // -gline-tables-only is Clang-only
     gn_args.push("line_tables_only=false".into());
-  } else if let Some(clang_base_path) = find_compatible_system_clang(target_os) {
+  } else if let Some(clang_base_path) = find_compatible_system_clang(&target_os) {
     println!("clang_base_path (system): {}", clang_base_path.display());
     gn_args.push(format!("clang_base_path={:?}", clang_base_path));
     gn_args.push("treat_warnings_as_errors=false".to_string());

--- a/build.rs
+++ b/build.rs
@@ -159,12 +159,6 @@ fn build_v8(is_asan: bool) {
     gn_args.push("use_custom_libcxx=false".to_string());
   }
 
-  if cfg!(target_os = "macos") {
-    gn_args.push("use_custom_libcxx=true".to_string());
-  } else {
-    gn_args.push("use_custom_libcxx=false".to_string());
-  }
-
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
     gn_args.push("host_cpu=\"arm64\"".to_string())

--- a/build.rs
+++ b/build.rs
@@ -631,7 +631,7 @@ fn print_link_flags() {
   println!("cargo:rustc-link-lib=dylib=icuuc");
   println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
   
-  println!("cargo:rustc-cdylib-link-arg=-D_LIBCPP_ABI_VERSION=1");
+  println!("cargo:rustc-dylib-link-arg=-D_LIBCPP_ABI_VERSION=1");
 
   // Add other necessary libraries...
 

--- a/build.rs
+++ b/build.rs
@@ -161,6 +161,8 @@ fn build_v8(is_asan: bool) {
     gn_args.push("use_custom_libcxx=false".to_string());
   }
 
+  gn_args.push(r#"extra_cflags = [ "-D_LIBCPP_DISABLE_ASSERTS" ]"#.to_string());
+
   gn_args.push(r#"default_symbol_visibility = "hidden""#.to_string());
   let repo_root = env::current_dir().unwrap();
   let abseil_options_path = repo_root
@@ -193,10 +195,10 @@ fn build_v8(is_asan: bool) {
     gn_args.push(format!("host_cpu=\"{}\"", host_arch));
 
     if target_arch == "x86_64" {
-      gn_args.push(r#"extra_cflags = [ "-arch", "x86_64" ]"#.to_string());
+      gn_args.push(r#"extra_cflags += [ "-arch", "x86_64" ]"#.to_string());
       gn_args.push(r#"extra_ldflags = [ "-arch", "x86_64" ]"#.to_string());
     } else if target_arch == "aarch64" {
-      gn_args.push(r#"extra_cflags = [ "-arch", "arm64" ]"#.to_string());
+      gn_args.push(r#"extra_cflags += [ "-arch", "arm64" ]"#.to_string());
       gn_args.push(r#"extra_ldflags = [ "-arch", "arm64" ]"#.to_string());
     }
   }

--- a/build.rs
+++ b/build.rs
@@ -633,18 +633,18 @@ fn print_link_flags() {
       println!("cargo:rustc-link-lib=dylib=icuuc");
       println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
       // macOS specific rpath
-      println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../lib");
+      // println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../lib");
   } else if cfg!(target_os = "linux") {
     // Link dynamic V8 libraries  
-      println!("cargo:rustc-link-lib=so=libv8_libplatform");
-      println!("cargo:rustc-link-lib=so=libv8_libbase");
-      println!("cargo:rustc-link-lib=so=libv8");
-      println!("cargo:rustc-link-lib=so=libc++");
-      println!("cargo:rustc-link-lib=so=libthird_party_icu_icui18n");
-      println!("cargo:rustc-link-lib=so=libicuuc");
-      println!("cargo:rustc-link-lib=so=libthird_party_abseil-cpp_absl");
-      // Linux specific rpath
-      println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
+      println!("cargo:rustc-link-lib=v8_libplatform");
+      println!("cargo:rustc-link-lib=v8_libbase");
+      println!("cargo:rustc-link-lib=v8");
+      println!("cargo:rustc-link-lib=c++");
+      println!("cargo:rustc-link-lib=third_party_icu_icui18n");
+      println!("cargo:rustc-link-lib=icuuc");
+      println!("cargo:rustc-link-lib=third_party_abseil-cpp_absl");
+
+      // println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
   } else if cfg!(target_os = "windows") {
       // Windows uses a different mechanism; rpath is not used
       // You might need to copy the DLLs next to the executable

--- a/build.rs
+++ b/build.rs
@@ -617,6 +617,25 @@ fn copy_archive(url: &str, filename: &Path) {
 
 fn print_link_flags() {
   println!("cargo:rustc-link-lib=static=rusty_v8");
+  println!("cargo:rustc-link-search=native=./target/release/gn_out");
+
+  // Link dynamic V8 libraries
+  println!("cargo:rustc-link-lib=dylib=v8");
+  println!("cargo:rustc-link-lib=dylib=v8_libplatform");
+  println!("cargo:rustc-link-lib=dylib=v8_libbase");
+  // Add other necessary libraries...
+
+  // Platform-specific linker arguments
+  if cfg!(target_os = "macos") {
+      // macOS specific rpath
+      println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../lib");
+  } else if cfg!(target_os = "linux") {
+      // Linux specific rpath
+      println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
+  } else if cfg!(target_os = "windows") {
+      // Windows uses a different mechanism; rpath is not used
+      // You might need to copy the DLLs next to the executable
+  }
   let should_dyn_link_libcxx = env::var("CARGO_FEATURE_USE_CUSTOM_LIBCXX")
     .is_err()
     || env::var("GN_ARGS").map_or(false, |gn_args| {

--- a/build.rs
+++ b/build.rs
@@ -159,6 +159,12 @@ fn build_v8(is_asan: bool) {
     gn_args.push("use_custom_libcxx=false".to_string());
   }
 
+  if cfg!(target_os = "macos") {
+    gn_args.push("use_custom_libcxx=true".to_string());
+  } else {
+    gn_args.push("use_custom_libcxx=false".to_string());
+  }
+
   // Fix GN's host_cpu detection when using x86_64 bins on Apple Silicon
   if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
     gn_args.push("host_cpu=\"arm64\"".to_string())

--- a/build.rs
+++ b/build.rs
@@ -1171,7 +1171,7 @@ fn patch_inspector_protocol() {
       .expect("Failed to read inspector_protocol.gni");
   
   // Patch the outputs_pre line
-  let old_line = "outputs_pre = get_path_info(rebase_path(invoker.outputs, \".\", invoker.out_dir), \"abspath\")";
+  let old_line = "outputs = get_path_info(rebase_path(invoker.outputs, \".\", invoker.out_dir),\n                            \"abspath\")";
   let new_lines = r#"outputs_pre = get_path_info(rebase_path(invoker.outputs, ".", invoker.out_dir), "abspath")
   outputs = []
   foreach(out, outputs_pre) {

--- a/build.rs
+++ b/build.rs
@@ -164,20 +164,26 @@ fn build_v8(is_asan: bool) {
     gn_args.push("host_cpu=\"arm64\"".to_string())
   }
 
-  if cfg!(target_os = "linux") {  let repo_root = env::current_dir().unwrap();
+  if cfg!(target_os = "macos") {
+    gn_args.push(r#"is_component_build = true"#.to_string());
+  } else {
+    let repo_root = env::current_dir().unwrap();
     let abseil_options_path = repo_root
       .join("third_party")
       .join("abseil-cpp")
       .join("absl")
       .join("base")
       .join("options.h");
-  
+
     modify_abseil_options(&abseil_options_path).expect("Failed to modify options.h");
-    gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
-    gn_args.push(r#"extra_ldflags = [ "-Wl,-Bsymbolic" ]"#.to_string());
-  } else {
-    gn_args.push(r#"is_component_build = true"#.to_string());
+
+    if cfg!(target_os = "linux") {
+      gn_args.push(r#"extra_cflags = [ "-fvisibility=hidden", "-fvisibility-inlines-hidden" ]"#.to_string());
+      gn_args.push(r#"extra_ldflags = [ "-Wl,-Bsymbolic" ]"#.to_string());
+    }
   }
+
+  
 
   if env::var_os("DISABLE_CLANG").is_some() {
     gn_args.push("is_clang=false".into());

--- a/build.rs
+++ b/build.rs
@@ -890,12 +890,13 @@ fn maybe_symlink_root_dir(dirs: &mut Dirs) {
   use std::os::windows::fs::symlink_dir;
 
   let get_prefix = |p: &Path| {
-    p.components()
+    let prefix = p.components()
       .find_map(|c| match c {
         std::path::Component::Prefix(p) => Some(p),
         _ => None,
       })
-      .map(|p| p.as_os_str().to_owned())
+      .map(|p| p.as_os_str().to_string_lossy().to_lowercase());
+    prefix
   };
 
   let Dirs { out, root } = dirs;

--- a/build.rs
+++ b/build.rs
@@ -1008,7 +1008,7 @@ pub fn build(target: &str, maybe_env: Option<NinjaEnv>) {
   }
 
   println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
-  //println!("cargo:rerun-if-env-changed=PROFILE");
+  println!("cargo:rerun-if-env-changed=PROFILE");
   rerun_if_changed(&gn_out_dir, maybe_env.clone(), target);
 
   // This helps Rust source files locate the snapshot, source map etc.

--- a/build.rs
+++ b/build.rs
@@ -167,6 +167,7 @@ fn build_v8(is_asan: bool) {
   if cfg!(target_os = "macos") {
     gn_args.push(r#"is_component_build = true"#.to_string());
   } else {
+    gn_args.push(r#"default_symbol_visibility = "hidden""#.to_string());
     let repo_root = env::current_dir().unwrap();
     let abseil_options_path = repo_root
       .join("third_party")

--- a/build.rs
+++ b/build.rs
@@ -1104,30 +1104,31 @@ pub fn parse_ninja_graph(s: &str) -> HashSet<String> {
 }
 
 fn modify_abseil_options(options_path: &PathBuf) -> io::Result<()> {
-  // Read the contents of options.h
-  let mut options_content = fs::read_to_string(&options_path)?;
+    // Read the contents of options.h
+    let current_content = fs::read_to_string(&options_path)?;
+    
+    // Create the expected content
+    let new_content = current_content
+        .lines()
+        .map(|line| {
+            if line.contains("#define ABSL_OPTION_USE_INLINE_NAMESPACE") {
+                "#define ABSL_OPTION_USE_INLINE_NAMESPACE 1".to_string()
+            } else if line.contains("#define ABSL_OPTION_INLINE_NAMESPACE_NAME") {
+                "#define ABSL_OPTION_INLINE_NAMESPACE_NAME v8".to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<String>>()
+        .join("\n");
+    
+    // Only write if content actually changed
+    if current_content != new_content {
+        let mut file = fs::File::create(&options_path)?;
+        file.write_all(new_content.as_bytes())?;
+    }
 
-  // Modify the necessary lines
-  // Replace the definitions of ABSL_OPTION_USE_INLINE_NAMESPACE and ABSL_OPTION_INLINE_NAMESPACE_NAME
-  options_content = options_content
-      .lines()
-      .map(|line| {
-          if line.contains("#define ABSL_OPTION_USE_INLINE_NAMESPACE") {
-              "#define ABSL_OPTION_USE_INLINE_NAMESPACE 1".to_string()
-          } else if line.contains("#define ABSL_OPTION_INLINE_NAMESPACE_NAME") {
-              "#define ABSL_OPTION_INLINE_NAMESPACE_NAME v8".to_string()
-          } else {
-              line.to_string()
-          }
-      })
-      .collect::<Vec<String>>()
-      .join("\n");
-
-  // Write the modified content back to options.h
-  let mut file = fs::File::create(&options_path)?;
-  file.write_all(options_content.as_bytes())?;
-
-  Ok(())
+    Ok(())
 }
 
 #[cfg(test)]

--- a/build.rs
+++ b/build.rs
@@ -622,29 +622,18 @@ fn print_link_flags() {
   println!("cargo:rustc-link-lib=static=rusty_v8");
   println!("cargo:rustc-link-search=native=./target/release/gn_out");
 
+  println!("cargo:rustc-link-lib=dylib=v8_libplatform");
+  println!("cargo:rustc-link-lib=dylib=v8_libbase");
+  println!("cargo:rustc-link-lib=dylib=v8");
+  println!("cargo:rustc-link-lib=dylib=third_party_icu_icui18n");
+  println!("cargo:rustc-link-lib=dylib=icuuc");
+  println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
+
   // Platform-specific linker arguments
   if cfg!(target_os = "macos") {
-      // Link dynamic V8 libraries  
-      println!("cargo:rustc-link-lib=dylib=v8_libplatform");
-      println!("cargo:rustc-link-lib=dylib=v8_libbase");
-      println!("cargo:rustc-link-lib=dylib=v8");
       println!("cargo:rustc-link-lib=dylib=c++_chrome");
-      println!("cargo:rustc-link-lib=dylib=third_party_icu_icui18n");
-      println!("cargo:rustc-link-lib=dylib=icuuc");
-      println!("cargo:rustc-link-lib=dylib=third_party_abseil-cpp_absl");
-      // macOS specific rpath
-      // println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../lib");
   } else if cfg!(target_os = "linux") {
-    // Link dynamic V8 libraries  
-      println!("cargo:rustc-link-lib=v8_libplatform");
-      println!("cargo:rustc-link-lib=v8_libbase");
-      println!("cargo:rustc-link-lib=v8");
-      println!("cargo:rustc-link-lib=c++");
-      println!("cargo:rustc-link-lib=third_party_icu_icui18n");
-      println!("cargo:rustc-link-lib=icuuc");
-      println!("cargo:rustc-link-lib=third_party_abseil-cpp_absl");
-
-      // println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
+      println!("cargo:rustc-link-lib=dylib=c++");
   } else if cfg!(target_os = "windows") {
       // Windows uses a different mechanism; rpath is not used
       // You might need to copy the DLLs next to the executable


### PR DESCRIPTION
 - [x] `is_component_build = true` is the main flag to make V8 build to shared libraries
 - [x] in build.rs, override check for `V8_FROM_SOURCE` with `true` so this fork will have changes to V8 build applied within cargo builds of consuming projects without having to set this flag
 - [x] list all dylibs created by V8 in build.rs to have cargo link against those accordingly
 - [x] get all needed objects to be linked into a complete set of dylibs so we don't have unresolved symbols when building a consuming executable project